### PR TITLE
[ISSUE-08] replace basefeaturedetails with featuredetails

### DIFF
--- a/src/GDCFeatureWidget/GDCFeatureWidget.js
+++ b/src/GDCFeatureWidget/GDCFeatureWidget.js
@@ -23,7 +23,7 @@ export default jbrowse => {
   const React = jbrowse.jbrequire('react')
   const { useState, useEffect } = React
 
-  const { BaseFeatureDetails, BaseCard } = jbrowse.jbrequire(
+  const { FeatureDetails, BaseCard } = jbrowse.jbrequire(
     '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail',
   )
 
@@ -594,7 +594,7 @@ export default jbrowse => {
     } = feat
     return (
       <Paper className={classes.root} data-testid="variant-widget">
-        <BaseFeatureDetails feature={rest} {...props} />
+        <FeatureDetails feature={rest} {...props} />
         <Divider />
         {feat.geneId && <GeneExternalLinks feature={feat} />}
         {feat.ssmId && <SSMExternalLinks feature={feat} />}


### PR DESCRIPTION
`@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail` does not export `BaseFeatureDetails`; using `FeatureDetails` instead because all the required information seems to be there...

comparing GDC for JB1 implementation:
![image](https://user-images.githubusercontent.com/83305007/117688915-3f8f7680-b187-11eb-9930-165fc3c9ccc7.png)

to revision with FeatureDetails:
![image](https://user-images.githubusercontent.com/83305007/117686434-df97d080-b184-11eb-9fb2-d8ee6630e379.png)

...all the required information seems to be there.

If BaseFeatureDetails is used via `import BaseFeatureDetails from '@jbrowse/core/BaseFeatureWidget/BaseFeatureDetail'` the related gene consequence(s) are dumped under 'attributes' in raw JSON:

![image](https://user-images.githubusercontent.com/83305007/117686313-bd9e4e00-b184-11eb-9bb3-e2b2f47fe4c9.png)

closes #8 