### PR TITLE
[seg-adapter-update] enforces refnames grabbed from the file rather than static values

### DIFF
--- a/src/SegmentCNVAdapter/SegmentCNVAdapter.ts
+++ b/src/SegmentCNVAdapter/SegmentCNVAdapter.ts
@@ -21,7 +21,7 @@ export default class SegmentCNVAdapter extends BaseFeatureDataAdapter {
     this.config = config
   }
 
-  public async getLines() {
+  private async getLines() {
     const segLocation = readConfObject(
       this.config,
       'segLocation',
@@ -46,19 +46,34 @@ export default class SegmentCNVAdapter extends BaseFeatureDataAdapter {
       })
   }
 
-  public async setup() {
+  private async setup() {
     if (!this.setupP) {
       this.setupP = this.getLines()
     }
     return this.setupP
   }
 
+  private async determineRefNamesFromFile() {
+    const segLocation = readConfObject(
+      this.config,
+      'segLocation',
+    ) as FileLocation
+    const lines = (await openLocation(segLocation).readFile('utf8')) as string
+
+    let refNames = lines
+      .split('\n')
+      .slice(1)
+      .filter(f => !!f)
+      .map(line => {
+        return line.split('\t')[1]
+      })
+
+    return Array.from(new Set(refNames))
+  }
+
   public async getRefNames(_: BaseOptions = {}) {
-    const l = []
-    for (let i = 0; i < 23; i++) {
-      l.push('' + i)
-    }
-    return l
+    const refNames = await this.determineRefNamesFromFile()
+    return refNames
   }
 
   public getFeatures(region: Region, opts: BaseOptions = {}) {

--- a/src/SegmentCNVAdapter/__snapshots__/SegmentCNVAdapter.test.ts.snap
+++ b/src/SegmentCNVAdapter/__snapshots__/SegmentCNVAdapter.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`adapter can fetch features from segments.txt 1`] = `
 Array [
-  "0",
   "1",
   "2",
   "3",
@@ -25,6 +24,8 @@ Array [
   "20",
   "21",
   "22",
+  "X",
+  "Y",
 ]
 `;
 


### PR DESCRIPTION
resolves #41 ; this ensures that refnames are not assumed to just be 1...23, as some seg files contain chr1...Y and need to be accommodated to be properly rendered