### PR TITLE
fix query for true iscancergenecensus and fixes colouration on filter

### DIFF
--- a/src/GDCFilterWidget/components/ColourFeatures.js
+++ b/src/GDCFilterWidget/components/ColourFeatures.js
@@ -50,7 +50,7 @@ const HighlightFeature = observer(({ schema, type }) => {
     } else if (hlBy.type === 'category') {
       colourFunction = `jexl:switch(feature,'${JSON.stringify(hlBy)}')`
     } else if (hlBy.type === 'boolean') {
-      colourFunction = `jexl:cast([get(feature,'${hlBy.attributeName}')] ? '${hlBy.values[0].colour1}' : '${hlBy.values[0].colour2}')`
+      colourFunction = `jexl:cancer(feature,'${hlBy.attributeName}')`
     } else if (hlBy.type === 'percentage') {
       colourFunction = `jexl:rgb(feature,'${hlBy.attributeName}')`
     } else {

--- a/src/GDCFilterWidget/components/Utility.js
+++ b/src/GDCFilterWidget/components/Utility.js
@@ -101,7 +101,7 @@ export const geneFacets = [
   {
     name: 'is_cancer_gene_census',
     prettyName: 'is cancer gene census',
-    values: ['1'],
+    values: ['true'],
   },
 ]
 export const caseFacets = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,5 +244,12 @@ export default class GDCPlugin extends Plugin {
         return `rgb(0,${percentage},0)`
       },
     )
+
+    pluginManager.jexl.addFunction(
+      'cancer',
+      (feature: any, attributeName: string) => {
+        return feature.get(attributeName) ? 'red' : 'blue'
+      },
+    )
   }
 }


### PR DESCRIPTION
resolves #58

- changes jexl colouration function to more certainly filter on 'have' or 'have-not' of is_cancer_gene_census property on gene filtering ;; cancerous genes are red while non-cancerous are blue
- fixes issue with query where '1' no longer coordinates with 'true' in filtering query