### PR TITLE
fix operand to capture features outside the queried boundary

### DIFF
--- a/src/GDCAdapter/GDCAdapter.ts
+++ b/src/GDCAdapter/GDCAdapter.ts
@@ -255,12 +255,12 @@ export default class GDCAdapter extends BaseFeatureDataAdapter {
             op: 'and',
             content: [
               {
-                op: '>=',
-                content: { field: 'ssms.start_position', value: start },
+                op: '<=',
+                content: { field: 'ssms.start_position', value: end },
               },
               {
-                op: '<=',
-                content: { field: 'ssms.end_position', value: end },
+                op: '>=',
+                content: { field: 'ssms.end_position', value: start },
               },
               {
                 op: '=',
@@ -275,10 +275,10 @@ export default class GDCAdapter extends BaseFeatureDataAdapter {
             op: 'and',
             content: [
               {
-                op: '>=',
-                content: { field: 'genes.gene_start', value: start },
+                op: '<=',
+                content: { field: 'genes.gene_start', value: end },
               },
-              { op: '<=', content: { field: 'genes.gene_end', value: end } },
+              { op: '>=', content: { field: 'genes.gene_end', value: start } },
               {
                 op: '=',
                 content: { field: 'genes.gene_chromosome', value: [chr] },


### PR DESCRIPTION
@cmdcolin 's suggested fix was the issue; defined boundaries for the genes were outside of what they needed to be properly displayed

resolves #57 