### PR TITLE
adding adapter for splice junction data

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,10 @@
     {
       "name": "GDC",
       "url": "http://localhost:9000/dist/jbrowse-plugin-gdc.umd.development.js"
+    },
+    {
+      "name": "Ideogram",
+      "url": "http://localhost:9080/dist/jbrowse-plugin-ideogram.umd.development.js"
     }
   ],
   "assemblies": [
@@ -15,31 +19,53 @@
         "adapter": {
           "type": "BgzipFastaAdapter",
           "fastaLocation": {
-            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz",
-            "locationType": "UriLocation"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz"
           },
           "faiLocation": {
-            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai",
-            "locationType": "UriLocation"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai"
           },
           "gziLocation": {
-            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi",
-            "locationType": "UriLocation"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi"
           }
+        },
+        "rendering": {
+          "type": "DivSequenceRenderer"
         }
       },
       "refNameAliases": {
         "adapter": {
           "type": "RefNameAliasAdapter",
           "location": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/GRCh38/hg38_aliases.txt",
-            "locationType": "UriLocation"
+            "uri": "https://jbrowse.org/genomes/GRCh38/hg38_aliases.txt"
           }
         }
       }
     }
   ],
   "tracks": [
+    {
+      "type": "FeatureTrack",
+      "trackId": "dbsuper",
+      "name": "dbSUPER adipose enhancers",
+      "assemblyNames": ["hg38"],
+      "adapter": {
+        "type": "BedTabixAdapter",
+        "bedGzLocation": {
+          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/dbSUPER/adipose_interactions.sorted.bed.gz"
+        },
+        "index": {
+          "location": {
+            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/dbSUPER/adipose_interactions.sorted.bed.gz.tbi"
+          }
+        }
+      },
+      "displays": [
+        {
+          "type": "LinearArcDisplay",
+          "displayId": "LinearBasicDisplay"
+        }
+      ]
+    },
     {
       "type": "FeatureTrack",
       "trackId": "ncbi_refseq_109_hg38_latest",
@@ -188,6 +214,46 @@
       }
     ]
   },
+  "savedSessions": [
+    {
+      "name": "Human Example (hg38)",
+      "width": 1850,
+      "drawerWidth": 384,
+      "views": [
+        {
+          "id": "MiDMyyWpp",
+          "type": "LinearGenomeView",
+          "width": 800,
+          "displayName": "Arc renderer demo",
+          "trackSelectorType": "hierarchical",
+          "offsetPx": 0,
+          "bpPerPx": 7798.966735482216,
+          "displayedRegions": [
+            {
+              "refName": "1",
+              "start": 0,
+              "end": 186700647,
+              "assemblyName": "hg38"
+            }
+          ],
+          "tracks": [
+            {
+              "type": "BasicTrack",
+              "configuration": "gencode_nclist_hg38",
+              "height": 100
+            },
+            {
+              "type": "BasicTrack",
+              "configuration": "genehancer_ucsc",
+              "height": 100
+            }
+          ],
+          "controlsWidth": 120,
+          "minimumBlockWidth": 20
+        }
+      ]
+    }
+  ],
   "internetAccounts": [
     {
       "type": "GDCInternetAccount",

--- a/config.json
+++ b/config.json
@@ -15,13 +15,16 @@
         "adapter": {
           "type": "BgzipFastaAdapter",
           "fastaLocation": {
-            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz",
+            "locationType": "UriLocation"
           },
           "faiLocation": {
-            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.fai",
+            "locationType": "UriLocation"
           },
           "gziLocation": {
-            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi"
+            "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi",
+            "locationType": "UriLocation"
           }
         },
         "rendering": {
@@ -32,36 +35,14 @@
         "adapter": {
           "type": "RefNameAliasAdapter",
           "location": {
-            "uri": "https://jbrowse.org/genomes/GRCh38/hg38_aliases.txt"
+            "uri": "https://jbrowse.org/genomes/GRCh38/hg38_aliases.txt",
+            "locationType": "UriLocation"
           }
         }
       }
     }
   ],
   "tracks": [
-    {
-      "type": "FeatureTrack",
-      "trackId": "dbsuper",
-      "name": "dbSUPER adipose enhancers",
-      "assemblyNames": ["hg38"],
-      "adapter": {
-        "type": "BedTabixAdapter",
-        "bedGzLocation": {
-          "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/dbSUPER/adipose_interactions.sorted.bed.gz"
-        },
-        "index": {
-          "location": {
-            "uri": "https://s3.amazonaws.com/jbrowse.org/genomes/hg19/dbSUPER/adipose_interactions.sorted.bed.gz.tbi"
-          }
-        }
-      },
-      "displays": [
-        {
-          "type": "LinearArcDisplay",
-          "displayId": "LinearBasicDisplay"
-        }
-      ]
-    },
     {
       "type": "FeatureTrack",
       "trackId": "ncbi_refseq_109_hg38_latest",
@@ -103,23 +84,6 @@
             },
             "type": "SvgFeatureRenderer"
           }
-        }
-      ]
-    },
-    {
-      "type": "ICGCTrack",
-      "trackId": "icgc_plugin_track",
-      "name": "ICGC Browser",
-      "assemblyNames": ["hg38"],
-      "category": ["Annotation"],
-      "adapter": {
-        "ICGCAdapterId": "DefaultICGCAdapter",
-        "type": "ICGCAdapter"
-      },
-      "displays": [
-        {
-          "type": "LinearICGCDisplay",
-          "displayId": "icgc_plugin_track_linear"
         }
       ]
     },

--- a/config.json
+++ b/config.json
@@ -26,9 +26,6 @@
             "uri": "https://jbrowse.org/genomes/GRCh38/fasta/hg38.prefix.fa.gz.gzi",
             "locationType": "UriLocation"
           }
-        },
-        "rendering": {
-          "type": "DivSequenceRenderer"
         }
       },
       "refNameAliases": {
@@ -191,46 +188,6 @@
       }
     ]
   },
-  "savedSessions": [
-    {
-      "name": "Human Example (hg38)",
-      "width": 1850,
-      "drawerWidth": 384,
-      "views": [
-        {
-          "id": "MiDMyyWpp",
-          "type": "LinearGenomeView",
-          "width": 800,
-          "displayName": "Arc renderer demo",
-          "trackSelectorType": "hierarchical",
-          "offsetPx": 0,
-          "bpPerPx": 7798.966735482216,
-          "displayedRegions": [
-            {
-              "refName": "1",
-              "start": 0,
-              "end": 186700647,
-              "assemblyName": "hg38"
-            }
-          ],
-          "tracks": [
-            {
-              "type": "BasicTrack",
-              "configuration": "gencode_nclist_hg38",
-              "height": 100
-            },
-            {
-              "type": "BasicTrack",
-              "configuration": "genehancer_ucsc",
-              "height": 100
-            }
-          ],
-          "controlsWidth": 120,
-          "minimumBlockWidth": 20
-        }
-      ]
-    }
-  ],
   "internetAccounts": [
     {
       "type": "GDCInternetAccount",

--- a/config.json
+++ b/config.json
@@ -3,10 +3,6 @@
     {
       "name": "GDC",
       "url": "http://localhost:9000/dist/jbrowse-plugin-gdc.umd.development.js"
-    },
-    {
-      "name": "Ideogram",
-      "url": "http://localhost:9080/dist/jbrowse-plugin-ideogram.umd.development.js"
     }
   ],
   "assemblies": [
@@ -107,6 +103,23 @@
             },
             "type": "SvgFeatureRenderer"
           }
+        }
+      ]
+    },
+    {
+      "type": "ICGCTrack",
+      "trackId": "icgc_plugin_track",
+      "name": "ICGC Browser",
+      "assemblyNames": ["hg38"],
+      "category": ["Annotation"],
+      "adapter": {
+        "ICGCAdapterId": "DefaultICGCAdapter",
+        "type": "ICGCAdapter"
+      },
+      "displays": [
+        {
+          "type": "LinearICGCDisplay",
+          "displayId": "icgc_plugin_track_linear"
         }
       ]
     },

--- a/src/GDCSearchWidget/GDCDataInfo.test.ts
+++ b/src/GDCSearchWidget/GDCDataInfo.test.ts
@@ -7,7 +7,14 @@ const locationType = 'UriLocation'
 const datenow = () => Date.now()
 
 test('maps data information to CNV', async () => {
-  const result = mapDataInfo('txt-Copy Number Variation', uri)
+  const result = mapDataInfo(
+    {
+      type: 'Copy Number Segment',
+      category: 'Copy Number Variation',
+      format: 'txt',
+    },
+    uri,
+  )
 
   expect(result).toEqual({
     config: {
@@ -28,7 +35,11 @@ test('maps data information to CNV', async () => {
 
 test('maps data information to BAM', async () => {
   const indexId = 'some-unique-id'
-  const result = mapDataInfo('bam-Sequencing Reads', uri, indexId)
+  const result = mapDataInfo(
+    { type: 'Aligned Reads', category: 'Sequencing Reads', format: 'bam' },
+    uri,
+    indexId,
+  )
 
   expect(result).toEqual({
     config: {
@@ -51,7 +62,14 @@ test('maps data information to BAM', async () => {
 })
 
 test('maps data information to SNV', async () => {
-  const result = mapDataInfo('vcf-Simple Nucleotide Variation', uri)
+  const result = mapDataInfo(
+    {
+      type: 'Raw Simple Somatic Mutation',
+      category: 'Simple Nucleotide Variation',
+      format: 'vcf',
+    },
+    uri,
+  )
 
   expect(result).toEqual({
     config: {
@@ -75,7 +93,14 @@ test('maps data information to SNV', async () => {
   const dateNowStub = jest.fn(() => 1530518207007)
   global.Date.now = dateNowStub
 
-  const result = mapDataInfo('maf-Simple Nucleotide Variation', uri)
+  const result = mapDataInfo(
+    {
+      type: 'Masked Somatic Mutation',
+      category: 'Simple Nucleotide Variation',
+      format: 'maf',
+    },
+    uri,
+  )
 
   expect(result).toEqual({
     config: {
@@ -100,7 +125,14 @@ test('maps data information to IEQ', async () => {
   const dateNowStub = jest.fn(() => 1530518207007)
   global.Date.now = dateNowStub
 
-  const result = mapDataInfo('txt-Transcriptome Profiling', uri)
+  const result = mapDataInfo(
+    {
+      type: 'Isoform Expression Quantification',
+      category: 'Transcriptome Profiling',
+      format: 'txt',
+    },
+    uri,
+  )
 
   expect(result).toEqual({
     config: {

--- a/src/GDCSearchWidget/GDCDataInfo.ts
+++ b/src/GDCSearchWidget/GDCDataInfo.ts
@@ -1,62 +1,46 @@
 import { storeBlobLocation } from '@jbrowse/core/util/tracks'
 
+export interface FileInfo {
+  [key: string]: unknown
+  type: string
+  category: string
+  format: string
+}
+
 const mapToAdapter: Map<string, Object> = new Map([
   [
-    'txt-Copy Number Variation',
-    {
-      config: {
-        type: 'QuantitativeTrack',
-        adapter: { type: 'SegmentCNVAdapter' },
-      },
-      prefix: 'seg',
-    },
-  ],
-  [
-    'tsv-Copy Number Variation',
-    {
-      config: {
-        type: 'QuantitativeTrack',
-        adapter: { type: 'SegmentCNVAdapter' },
-      },
-      prefix: 'seg',
-    },
-  ],
-  [
-    'bam-Sequencing Reads',
+    'bam',
     {
       config: { type: 'AlignmentsTrack', adapter: { type: 'BamAdapter' } },
       prefix: 'bam',
     },
   ],
   [
-    'vcf-Simple Nucleotide Variation',
+    'maf',
+    {
+      config: { type: 'MAFTrack', adapter: { type: 'MafAdapter' } },
+      prefix: 'maf',
+    },
+  ],
+  [
+    'vcf',
     {
       config: { type: 'VariantTrack', adapter: { type: 'VcfAdapter' } },
       prefix: 'vcf',
     },
   ],
   [
-    'maf-Simple Nucleotide Variation',
+    'Copy Number Variation',
     {
       config: {
-        type: 'MAFTrack',
-        adapter: { type: 'MafAdapter' },
+        type: 'QuantitativeTrack',
+        adapter: { type: 'SegmentCNVAdapter' },
       },
-      prefix: 'maf',
+      prefix: 'seg',
     },
   ],
   [
-    'txt-Transcriptome Profiling',
-    {
-      config: {
-        type: 'IEQTrack',
-        adapter: { type: 'IeqAdapter' },
-      },
-      prefix: 'ieq',
-    },
-  ],
-  [
-    'txt-DNA Methylation',
+    'Methylation Beta Value',
     {
       config: {
         type: 'FeatureTrack',
@@ -66,13 +50,24 @@ const mapToAdapter: Map<string, Object> = new Map([
     },
   ],
   [
-    'tsv-Transcriptome Profiling',
+    'Isoform Expression Quantification',
     {
       config: {
         type: 'IEQTrack',
         adapter: { type: 'IeqAdapter' },
       },
       prefix: 'ieq',
+    },
+  ],
+  [
+    'Splice Junction Quantification',
+    {
+      config: {
+        type: 'FeatureTrack',
+        adapter: { type: 'SjqAdapter' },
+        displays: [{ type: 'LinearArcDisplay' }],
+      },
+      prefix: 'sjq',
     },
   ],
   [
@@ -89,20 +84,32 @@ const mapToAdapter: Map<string, Object> = new Map([
   ],
 ])
 
+function getPriorityProperty(fileInfo: FileInfo) {
+  if (mapToAdapter.has(fileInfo.type)) {
+    return fileInfo.type
+  } else if (mapToAdapter.has(fileInfo.category)) {
+    return fileInfo.category
+  } else if (mapToAdapter.has(fileInfo.format)) {
+    return fileInfo.format
+  } else {
+    return ''
+  }
+}
+
 /**
- * maps the data info to an appropriate data adapter
- * @param category the data category of the file
+ * retrieves the config object with appropriate adapter using file info
+ * @param fileInfo an array of the format, category, and type of the file
  * @param uri the uri of the data
  * @param indexFileId the fileId of the index file that the data may require (BAM)
  * @returns an object containing the config type and the adapter object
  */
 export function mapDataInfo(
-  category: string,
+  fileInfo: FileInfo,
   uri?: any,
   indexFileId?: string,
   fileBlob?: any,
 ) {
-  const configObject = mapToAdapter.get(category)
+  const configObject = mapToAdapter.get(getPriorityProperty(fileInfo))
   let token = window.sessionStorage.getItem('GDCExternalToken-token')
 
   if (!token) {

--- a/src/GDCSearchWidget/ImportPanel.tsx
+++ b/src/GDCSearchWidget/ImportPanel.tsx
@@ -216,7 +216,6 @@ const Panel = ({ model }: { model: any }) => {
         name,
         assemblyNames: ['hg38'],
       }
-      console.log(conf)
       //@ts-ignore
       session.addTrackConf({
         ...conf,

--- a/src/GDCSearchWidget/ImportPanel.tsx
+++ b/src/GDCSearchWidget/ImportPanel.tsx
@@ -1,10 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { observer } from 'mobx-react'
-import {
-  FileLocation,
-  getSession,
-  useDebouncedCallback,
-} from '@jbrowse/core/util'
+import { getSession } from '@jbrowse/core/util'
 import { storeBlobLocation } from '@jbrowse/core/util/tracks'
 import {
   Paper,
@@ -220,6 +216,7 @@ const Panel = ({ model }: { model: any }) => {
         name,
         assemblyNames: ['hg38'],
       }
+      console.log(conf)
       //@ts-ignore
       session.addTrackConf({
         ...conf,
@@ -256,38 +253,30 @@ const Panel = ({ model }: { model: any }) => {
 
   /**
    * helper function to determine the file type of a dragged file. needed because files like BAM and VCF do not
-   * have inherent types to extract from the File object. this function needs to be modified whenever new file
-   * types are to be supported. files with several extensions can be supported in the future
+   * have inherent types to extract from the File object
    * @param fileName the name of the file to determine the extension
-   * @returns the type of the file that coordinates with the keys in GDCDataInfo
+   * @returns an object of type fileInfo that contains the file format, type, and/or category of the file based on its name
    */
-  function determineFileType(fileName: string) {
-    const fileNameArray = fileName.split('.')
+  function determineFileInfo(fileName: string) {
+    const format = fileName.split('.')[-1]
 
     if (fileName.includes('Methylation')) {
-      return 'txt-DNA Methylation'
-    }
-
-    for (const e of fileNameArray) {
-      switch (e) {
-        case 'seg':
-          return 'txt-Copy Number Variation'
-        case 'vcf':
-          return 'vcf-Simple Nucleotide Variation'
-        case 'maf':
-          return 'maf-Simple Nucleotide Variation'
-        case 'txt':
-          return 'txt-Transcriptome Profiling'
-        case 'tsv':
-          return 'tsv-Transcriptome Profiling'
-        case 'json':
-          return 'json'
-        case 'bedpe':
-          return 'bedpe'
+      return {
+        format,
+        type: 'Methylation Beta Value',
+        category: 'DNA Methylation',
       }
     }
 
-    return ''
+    if (fileName.includes('splice')) {
+      return {
+        format,
+        type: 'Splice Junction Quantification',
+        category: 'Transcriptome Profiling',
+      }
+    }
+
+    return { format, type: '', category: '' }
   }
 
   function resetErrorMessages() {
@@ -337,12 +326,12 @@ const Panel = ({ model }: { model: any }) => {
 
       const [file] = acceptedFiles
       if (file) {
-        const type = determineFileType(file.name)
+        const fileInfo = determineFileInfo(file.name)
         try {
           /**
            * JSON files are for bulk import of files from the GDC site
            */
-          if (type == 'json') {
+          if (fileInfo.format == 'json') {
             const res = await new Promise(resolve => {
               const reader = new FileReader()
               reader.addEventListener('load', event =>
@@ -367,9 +356,9 @@ const Panel = ({ model }: { model: any }) => {
                   data_category: string
                   file_type: string
                 }) => {
-                  const category = determineFileType(file.file_name)
+                  const iterFileInfo = determineFileInfo(file.file_name)
                   const uri = `http://localhost:8010/proxy/data/${file.file_id}`
-                  const typeAdapterObject = mapDataInfo(category, uri)
+                  const typeAdapterObject = mapDataInfo(iterFileInfo, uri)
                   addAndShowTrack(
                     typeAdapterObject,
                     file.file_id,
@@ -384,7 +373,7 @@ const Panel = ({ model }: { model: any }) => {
               console.error(message)
               setDragErrorMessage(message)
             }
-          } else if (type === 'bedpe') {
+          } else if (fileInfo.type === 'bedpe') {
             await addBEDPEView(file.name, undefined, file)
             setDragSuccess(true)
           } else {
@@ -438,9 +427,8 @@ const Panel = ({ model }: { model: any }) => {
             // all other files go through this channel
             if (!(/\.bam$/i.test(file.name) || /\.bai$/i.test(file.name))) {
               const trackId = `gdc_plugin_track-${Date.now()}`
-              //TODO: update this to go through the enhancement 2135 workflow
               const typeAdapterObject = mapDataInfo(
-                type,
+                fileInfo,
                 undefined,
                 undefined,
                 file,
@@ -535,9 +523,11 @@ const Panel = ({ model }: { model: any }) => {
             'Failed to add track.\nThis is a controlled resource that requires an authenticated token provided to the GDC Login to access.',
           )
         } else {
-          const category = `${response.data.data_format.toLowerCase()}-${
-            response.data.data_category
-          }`
+          const fileInfo = {
+            category: response.data.data_category,
+            format: response.data.data_format.toLowerCase(),
+            type: response.data.data_type,
+          }
           // BAM files require an index file, if the response contains index_files, then we want to utilize it
           const indexFileId = response.data.index_files
             ? response.data.index_files[0].file_id
@@ -545,8 +535,8 @@ const Panel = ({ model }: { model: any }) => {
           const uri = `http://localhost:8010/proxy/data/${query}`
           const trackId = `${response.data.file_id}`
           const trackName = `${response.data.file_name}`
-          if (category !== 'bedpe-Structural Variation') {
-            const typeAdapterObject = mapDataInfo(category, uri, indexFileId)
+          if (fileInfo.type !== 'bedpe') {
+            const typeAdapterObject = mapDataInfo(fileInfo, uri, indexFileId)
             addAndShowTrack(typeAdapterObject, trackId, trackName)
           } else {
             await addBEDPEView(response.data.file_id, uri)

--- a/src/MAFAdapter/MafAdapter.ts
+++ b/src/MAFAdapter/MafAdapter.ts
@@ -9,10 +9,9 @@ import MafFeature from './MafFeature'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { readConfObject } from '@jbrowse/core/configuration'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
-import { unzip } from '@gmod/bgzf-filehandle'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { getSubAdapterType } from '@jbrowse/core/data_adapters/dataAdapterCache'
-
+import pako from 'pako'
 export default class MafAdapter extends BaseFeatureDataAdapter {
   public static capabilities = ['getFeatures', 'getRefNames']
 
@@ -91,7 +90,7 @@ export default class MafAdapter extends BaseFeatureDataAdapter {
       typeof fileContents[2] === 'number' &&
       fileContents[2] === 8
     ) {
-      fileContents = new TextDecoder().decode(await unzip(fileContents))
+      fileContents = new TextDecoder().decode(pako.inflate(fileContents))
     } else {
       fileContents = fileContents.toString()
     }

--- a/src/MBVAdapter/MbvAdapter.ts
+++ b/src/MBVAdapter/MbvAdapter.ts
@@ -9,9 +9,9 @@ import MbvFeature from './MbvFeature'
 import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { readConfObject } from '@jbrowse/core/configuration'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
-import { unzip } from '@gmod/bgzf-filehandle'
 import PluginManager from '@jbrowse/core/PluginManager'
 import { getSubAdapterType } from '@jbrowse/core/data_adapters/dataAdapterCache'
+import pako from 'pako'
 
 export default class MbvAdapter extends BaseFeatureDataAdapter {
   public static capabilities = ['getFeatures', 'getRefNames']
@@ -91,7 +91,7 @@ export default class MbvAdapter extends BaseFeatureDataAdapter {
       typeof fileContents[2] === 'number' &&
       fileContents[2] === 8
     ) {
-      fileContents = new TextDecoder().decode(await unzip(fileContents))
+      fileContents = new TextDecoder().decode(pako.inflate(fileContents))
     } else {
       fileContents = fileContents.toString()
     }

--- a/src/SJQAdapter/SjqAdapter.test.ts
+++ b/src/SJQAdapter/SjqAdapter.test.ts
@@ -1,0 +1,30 @@
+import { toArray } from 'rxjs/operators'
+import SjqAdapter from './SjqAdapter'
+import configSchema from './configSchema'
+import fetchMock from 'jest-fetch-mock'
+
+fetchMock.enableMocks()
+
+test('adapter can fetch features from sjq_test_data.txt', async () => {
+  const adapter = new SjqAdapter(
+    configSchema.create({
+      sjqLocation: {
+        localPath: require.resolve('./test_data/sjq_test_data.txt'),
+      },
+    }),
+  )
+
+  const features = adapter.getFeatures({
+    assemblyName: 'volvox',
+    refName: 'chr9',
+    start: 94175962,
+    end: 94175981,
+  })
+
+  const names = await adapter.getRefNames()
+  expect(names).toMatchSnapshot()
+
+  const featuresArray = await features.pipe(toArray()).toPromise()
+  const featuresJsonArray = featuresArray.map(f => f.toJSON())
+  expect(featuresJsonArray).toMatchSnapshot()
+})

--- a/src/SJQAdapter/SjqAdapter.ts
+++ b/src/SJQAdapter/SjqAdapter.ts
@@ -1,0 +1,154 @@
+import {
+  BaseFeatureDataAdapter,
+  BaseOptions,
+} from '@jbrowse/core/data_adapters/BaseAdapter'
+import { FileLocation, Region } from '@jbrowse/core/util/types'
+import { openLocation } from '@jbrowse/core/util/io'
+import { ObservableCreate } from '@jbrowse/core/util/rxjs'
+import SjqFeature from './SjqFeature'
+import { Feature } from '@jbrowse/core/util/simpleFeature'
+import { readConfObject } from '@jbrowse/core/configuration'
+import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
+import PluginManager from '@jbrowse/core/PluginManager'
+import { unzip } from '@gmod/bgzf-filehandle'
+import { getSubAdapterType } from '@jbrowse/core/data_adapters/dataAdapterCache'
+
+function isGzip(buf: Buffer) {
+  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
+}
+/**
+ * Splice Junction Quantification Adapter
+ */
+export default class SjqAdapter extends BaseFeatureDataAdapter {
+  public static capabilities = ['getFeatures', 'getRefNames']
+
+  public config: any
+
+  private setupP?: Promise<Feature[]>
+
+  public constructor(
+    config: AnyConfigurationModel,
+    getSubAdapter?: getSubAdapterType,
+    pluginManager?: PluginManager,
+  ) {
+    // @ts-ignore
+    super(config, getSubAdapter, pluginManager)
+    this.config = config
+  }
+
+  private async readSjq(fileContents: string) {
+    const lines = fileContents.split('\n')
+    const rows: string[] = []
+    let columns: string[] = []
+    lines.forEach(line => {
+      if (line) {
+        if (columns.length === 0) {
+          columns = line.split('\t')
+        } else {
+          rows.push(line)
+        }
+      }
+    })
+
+    return {
+      lines: rows,
+      columns,
+    }
+  }
+
+  private async decodeFileContents() {
+    const buffer = await openLocation(
+      readConfObject(this.config, 'sjqLocation'),
+      this.pluginManager,
+    ).readFile()
+
+    const buf = isGzip(buffer as Buffer)
+      ? await unzip(buffer)
+      : buffer.toString()
+    // 512MB  max chrome string length is 512MB
+    if (buf && buf.length > 536_870_888) {
+      throw new Error('Data exceeds maximum string length (512MB)')
+    }
+    const data = new TextDecoder('utf8', { fatal: true }).decode(
+      buf as BufferSource,
+    )
+    return this.readSjq(data)
+  }
+
+  private parseLine(line: string, columns: string[]) {
+    let sjq: any = {}
+    line.split('\t').forEach((property: string, i: number) => {
+      // Source: https://stackoverflow.com/questions/4374822/remove-all-special-characters-with-regexp
+      columns[i] = columns[i].toLowerCase().replace(/[^\w\s]/gi, '')
+      if (property) {
+        sjq[columns[i].toLowerCase()] = property
+      }
+    })
+    return sjq
+  }
+
+  private async getLines() {
+    const { columns, lines } = await this.decodeFileContents()
+
+    return lines.map((line, index) => {
+      return new SjqFeature({
+        sjq: this.parseLine(line, columns),
+        id: `${this.id}-sjq-${index}`,
+      })
+    })
+  }
+
+  private async setup() {
+    if (!this.setupP) {
+      this.setupP = this.getLines()
+    }
+    return this.setupP
+  }
+
+  public async getRefNames(_: BaseOptions = {}) {
+    return [
+      'chr1',
+      'chr2',
+      'chr3',
+      'chr4',
+      'chr5',
+      'chr6',
+      'chr7',
+      'chr8',
+      'chr9',
+      'chr10',
+      'chr11',
+      'chr12',
+      'chr13',
+      'chr14',
+      'chr15',
+      'chr16',
+      'chr17',
+      'chr18',
+      'chr19',
+      'chr20',
+      'chr21',
+      'chr22',
+      'chrX',
+      'chrY',
+    ]
+  }
+
+  public getFeatures(region: Region, opts: BaseOptions = {}) {
+    return ObservableCreate<Feature>(async observer => {
+      const feats = await this.setup()
+      feats.forEach(f => {
+        if (
+          f.get('refName') === region.refName &&
+          f.get('end') > region.start &&
+          f.get('start') < region.end
+        ) {
+          observer.next(f)
+        }
+      })
+      observer.complete()
+    }, opts.signal)
+  }
+
+  public freeResources(): void {}
+}

--- a/src/SJQAdapter/SjqAdapter.ts
+++ b/src/SJQAdapter/SjqAdapter.ts
@@ -10,12 +10,9 @@ import { Feature } from '@jbrowse/core/util/simpleFeature'
 import { readConfObject } from '@jbrowse/core/configuration'
 import { AnyConfigurationModel } from '@jbrowse/core/configuration/configurationSchema'
 import PluginManager from '@jbrowse/core/PluginManager'
-import { unzip } from '@gmod/bgzf-filehandle'
 import { getSubAdapterType } from '@jbrowse/core/data_adapters/dataAdapterCache'
+import pako from 'pako'
 
-function isGzip(buf: Buffer) {
-  return buf[0] === 31 && buf[1] === 139 && buf[2] === 8
-}
 /**
  * Splice Junction Quantification Adapter
  */
@@ -76,7 +73,7 @@ export default class SjqAdapter extends BaseFeatureDataAdapter {
       typeof fileContents[2] === 'number' &&
       fileContents[2] === 8
     ) {
-      fileContents = new TextDecoder().decode(await unzip(fileContents))
+      fileContents = new TextDecoder().decode(pako.inflate(fileContents))
     } else {
       fileContents = fileContents.toString()
     }

--- a/src/SJQAdapter/SjqFeature.ts
+++ b/src/SJQAdapter/SjqFeature.ts
@@ -1,0 +1,67 @@
+import { Feature } from '@jbrowse/core/util/simpleFeature'
+
+interface FeatureData {
+  [key: string]: unknown
+  refName: string
+  start: number
+  end: number
+  name?: string
+}
+
+/**
+ * Splice Junction Quantification Adapter
+ */
+export default class SjqFeature implements Feature {
+  private sjq: any
+  private data: FeatureData
+  private _id: string
+
+  constructor(args: { sjq: any; id: string }) {
+    this.sjq = args.sjq
+    this.data = this.dataFromSjq(this.sjq)
+    this._id = args.id
+  }
+
+  get(field: string): any {
+    return this.data[field] || this.sjq[field]
+  }
+
+  set(): void {}
+
+  parent(): undefined {
+    return undefined
+  }
+
+  children(): undefined {
+    return undefined
+  }
+
+  tags(): string[] {
+    const t = [...Object.keys(this.data), ...Object.keys(this.sjq)]
+    return t
+  }
+
+  id(): string {
+    return this._id
+  }
+
+  // #chromosome	intron_start	intron_end	strand	intron_motif	annotation	n_unique_map	n_multi_map	max_splice_overhang
+  dataFromSjq(sjq: any): FeatureData {
+    const featureData: FeatureData = {
+      refName: sjq.chromosome,
+      start: +sjq.intron_start - 1,
+      end: +sjq.intron_end,
+      score: +sjq.n_unique_map + +sjq.n_multi_map,
+      name: `unique: ${sjq.n_unique_map}, multi: ${sjq.n_multi_map}`,
+    }
+    return featureData
+  }
+
+  toJSON(): any {
+    return {
+      uniqueId: this._id,
+      ...this.sjq,
+      ...this.data,
+    }
+  }
+}

--- a/src/SJQAdapter/__snapshots__/SjqAdapter.test.ts.snap
+++ b/src/SJQAdapter/__snapshots__/SjqAdapter.test.ts.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`adapter can fetch features from sjq_test_data.txt 1`] = `
+Array [
+  "chr1",
+  "chr2",
+  "chr3",
+  "chr4",
+  "chr5",
+  "chr6",
+  "chr7",
+  "chr8",
+  "chr9",
+  "chr10",
+  "chr11",
+  "chr12",
+  "chr13",
+  "chr14",
+  "chr15",
+  "chr16",
+  "chr17",
+  "chr18",
+  "chr19",
+  "chr20",
+  "chr21",
+  "chr22",
+  "chrX",
+  "chrY",
+]
+`;
+
+exports[`adapter can fetch features from sjq_test_data.txt 2`] = `
+Array [
+  Object {
+    "annotation": "1",
+    "chromosome": "chr9",
+    "end": 94175981,
+    "intron_end": "94175981",
+    "intron_motif": "1",
+    "intron_start": "94175962",
+    "max_splice_overhang": "1",
+    "n_multi_map": "1",
+    "n_unique_map": "0",
+    "name": "unique: 0, multi: 1",
+    "refName": "chr9",
+    "score": 1,
+    "start": 94175961,
+    "strand": "1",
+    "uniqueId": "test-sjq-0",
+  },
+]
+`;

--- a/src/SJQAdapter/configSchema.ts
+++ b/src/SJQAdapter/configSchema.ts
@@ -1,0 +1,12 @@
+import { ConfigurationSchema } from '@jbrowse/core/configuration'
+
+export default ConfigurationSchema(
+  'SjqAdapter',
+  {
+    sjqLocation: {
+      type: 'fileLocation',
+      defaultValue: { uri: '/path/to/myfile.tsv', locationType: 'UriLocation' },
+    },
+  },
+  { explicitlyTyped: true },
+)

--- a/src/SJQAdapter/index.ts
+++ b/src/SJQAdapter/index.ts
@@ -1,0 +1,2 @@
+export { default as configSchema } from './configSchema'
+export { default as AdapterClass } from './SjqAdapter'

--- a/src/SJQAdapter/test_data/sjq_test_data.txt
+++ b/src/SJQAdapter/test_data/sjq_test_data.txt
@@ -1,0 +1,2 @@
+#chromosome	intron_start	intron_end	strand	intron_motif	annotation	n_unique_map	n_multi_map	max_splice_overhang
+chr9	94175962	94175981	1	1	1	0	1	1

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,23 +45,15 @@ import {
   configSchema as ieqConfigSchema,
   AdapterClass as IeqAdapter,
 } from './IEQAdapter'
+import {
+  configSchema as sjqConfigSchema,
+  AdapterClass as SjqAdapter,
+} from './SJQAdapter'
 
 import {
   configSchema as GDCInternetAccountConfigSchema,
   modelFactory as GDCInternetAccountModelFactory,
 } from './GDCInternetAccount'
-
-async function fetchFileInfo(query: any) {
-  const response = await fetch(`http://localhost:8010/proxy/files/${query}`, {
-    method: 'GET',
-  })
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${response.status} ${response.statusText}`)
-  }
-  return response.json()
-}
-
 export default class GDCPlugin extends Plugin {
   name = 'GDCPlugin'
   version = version
@@ -99,6 +91,23 @@ export default class GDCPlugin extends Plugin {
     pluginManager.addAdapterType(
       () =>
         new AdapterType({
+          name: 'SjqAdapter',
+          configSchema: sjqConfigSchema,
+          // @ts-ignore
+          adapterMetadata: {
+            category: adapterCategoryHeader,
+            hiddenFromGUI: false,
+            displayName: 'Splice Junction Quantification Adapter',
+            description: '',
+          },
+          // @ts-ignore
+          AdapterClass: SjqAdapter,
+        }),
+    )
+
+    pluginManager.addAdapterType(
+      () =>
+        new AdapterType({
           name: 'MbvAdapter',
           configSchema: mbvConfigSchema,
           // @ts-ignore
@@ -122,7 +131,6 @@ export default class GDCPlugin extends Plugin {
           adapterHint?: string,
         ) => {
           const adapterName = 'MbvAdapter'
-          const displayName = 'Methylation Beta Value Adapter'
 
           if (adapterHint === adapterName) {
             return {
@@ -212,7 +220,6 @@ export default class GDCPlugin extends Plugin {
           adapterHint?: string,
         ) => {
           const adapterName = 'IeqAdapter'
-          const displayName = 'Isoform Expression Quantification Adapter'
 
           if (adapterHint === adapterName) {
             return {
@@ -263,7 +270,6 @@ export default class GDCPlugin extends Plugin {
         ) => {
           const regexGuess = /\.seg$/i
           const adapterName = 'SegmentCNVAdapter'
-          const displayName = 'Segment Copy Number Variation Adapter'
           const fileName = getFileName(file)
 
           if (regexGuess.test(fileName) || adapterHint === adapterName) {


### PR DESCRIPTION
## summary of changes

- adds new adapter type to accomodate for GDC splice junction data
- tracks of this type going through the GDC workflow utilize the new arc display (from core) by default
- refactors some of the data mapping for various gdc data types to be a little better handled